### PR TITLE
Update to composer 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     ssh \
     locales \
     less \
-    composer \
     sudo \
     mysql-server \
     npm
@@ -45,6 +44,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get autoclean -y && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     rm /var/lib/mysql/ib_logfile*
+
+# Install Composer 2
+RUN - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+    - php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+    - php composer-setup.php
+    - php -r "unlink('composer-setup.php');"
 
 # Ensure UTF-8
 ENV LANG       en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     rm /var/lib/mysql/ib_logfile*
 
 # Install Composer 2
-RUN - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    - php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-    - php composer-setup.php
-    - php -r "unlink('composer-setup.php');"
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+    php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+    php composer-setup.php && \
+    php -r "unlink('composer-setup.php');"
 
 # Ensure UTF-8
 ENV LANG       en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 # Install Composer 2
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
     php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
-    php composer-setup.php && \
+    php composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
     php -r "unlink('composer-setup.php');"
 
 # Ensure UTF-8


### PR DESCRIPTION
I use this pipeline for my projects in bitbucket, but for some projects, I have an error with the composer install command. I must use composer 2.
So I edit this pipeline to update composer to the version 2. My pull request has been tested and it's work.

If you want, I can make pull requests to update composer for your other bitbucket-pipelines-php7X.